### PR TITLE
Fix the text in options in status select dropdown

### DIFF
--- a/app/views/select_status.erb
+++ b/app/views/select_status.erb
@@ -52,7 +52,7 @@
       agendaItem: {},
       selected: '--',
       options: [
-        { status: 'passed', value: 'passed' },
+        { text: 'passed', value: 'passed' },
         { text: 'defeated', value: 'defeated' },
         { text: 'amended', value: 'amended' },
         { text: 'active', value: 'active' },


### PR DESCRIPTION
forgot to change a field in options from 'status' to 'text'