### PR TITLE
Add a rich text editor to agenda item's discussion text area

### DIFF
--- a/app/actions.rb
+++ b/app/actions.rb
@@ -17,6 +17,10 @@ get '/select' do
   erb :select_status
 end
 
+get '/richtext' do 
+  erb :rich_text_discussion
+end
+
 #################
 # FILE UPLOADER #
 #################

--- a/app/views/rich_text_discussion.erb
+++ b/app/views/rich_text_discussion.erb
@@ -1,0 +1,77 @@
+<div id="app">
+<div v-for="agendaItem in agendaItems">
+    <agenda-item :agenda-item="agendaItem"></agenda-item>
+  </div>
+    <agenda-item :agenda-item="agendaItem"></agenda-item>
+</div>
+
+<template id="agenda-item-template" >
+ <form @submit.prevent="postData">
+    <i v-if="agendaItem.type === 'Business'" class="fa fa-briefcase" aria-hidden="true"></i>
+    <i v-if="agendaItem.type === 'Document'" class="fa fa-file-document" aria-hidden="true"></i>
+    <i v-if="agendaItem.type === 'Action Items'" class="fa fa-exclamation-circle-btb" aria-hidden="true"></i>
+    <i v-if="agendaItem.type === 'Meeting Details'" class="fa fa-library-books" aria-hidden="true"></i>
+    <i v-if="agendaItem.type === 'Motion'" class="fa fa-gavel" aria-hidden="true"></i>
+    <i v-if="agendaItem.type === 'Election'" class="fa fa-checkbox-multiple-marked-outline" aria-hidden="true"></i>
+    <textarea id="title" v-model="agendaItem.title" name="title"></textarea>
+    <textarea id="description" v-model="agendaItem.description"  name="description"></textarea>
+    <textarea id="discussion" v-model="agendaItem.discussion" name="discussion" class="mceEditor" v-on:focus="tinyMCE()"></textarea>
+    <button type="submit">submit</button>
+  </form>
+</template>
+
+<script src="https://cdn.tinymce.com/4/tinymce.min.js"></script>
+
+<script>
+  Vue.component('agendaItem', {
+    template: '#agenda-item-template',
+    props: ['agendaItem'],
+    methods: {
+      postData: function() {
+        var mceContent = tinyMCE.activeEditor.getContent()
+        this.agendaItem.discussion = mceContent
+        console.log(this)
+        this.$http.post('/api/agenda-items/' + this.agendaItem.id, this.agendaItem, {emulateJSON:true}).then(function(response) {
+          console.log("agenda item updated");
+        }).error(function(error) {
+          console.log(error);
+          console.log("erroring");
+        }.bind(this));
+      },
+      tinyMCE: function() {
+        tinymce.init({
+          // General options
+          mode : "specific_textareas",
+          editor_selector : "mceEditor",
+          height: 200,
+          width: 500, 
+          plugins: [
+            'advlist autolink lists link image charmap print preview anchor',
+            'searchreplace visualblocks code fullscreen',
+            'insertdatetime media table contextmenu paste code',
+            'textcolor save'
+          ],
+          toolbar: 'insertfile undo redo | styleselect | bold italic forecolor | backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link | image | file | save',
+          content_css: [
+            '//fast.fonts.net/cssapi/e6dc9b99-64fe-4292-ad98-6974f93cd2a2.css',
+            '//www.tinymce.com/css/codepen.min.css'
+          ]
+        });
+      }
+    }
+  });
+
+  new Vue({
+    el: '#app',
+    data: function(){
+      return {
+        agendaItem: {}
+      }
+    },
+    created: function() {
+      this.$http.get('/api/agenda-items/1').then(function(response){
+        this.agendaItem = response.json();
+      }.bind(this));
+    }
+  });
+</script>


### PR DESCRIPTION
- on focus, normal text area converts to tinymce rich text editor (uses tiny mce CDN)
- uses tinymce's getContent function to capture HTML and CSS components and in-line styling inside the rich text editor
  > the discussion in the agenda item is then saved with the HTML tags and CSS in-line styles as a string
  > on a get request, the app remembers the styling inside the rich text editor so you have all your html components and css styles retrieved