### PR TITLE
Add associations to organization and user so user can be assigned to org

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,5 +1,7 @@
 class Organization < ActiveRecord::Base
 
+  has_many :user
+
   validates :name,
     presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ActiveRecord::Base
   self.inheritance_column = nil
+
+  belongs_to :organization
   
   has_many :meeting_permissions
   has_many :meetings, through: :meeting_permissions


### PR DESCRIPTION
- did a quick association for MVP so that a user can be assigned to org_id = 1
- in the future, we need to make this consistent with how we want our app to work:
  > an organization has_one user but multiple responsible users (of agenda items aka board members)
  > a user (creator) belongs to organization? similar to how there is a meeting creator?