### PR TITLE
Add associations to Meeting and AgendaItem models

### DIFF
--- a/app/models/agenda_item.rb
+++ b/app/models/agenda_item.rb
@@ -22,4 +22,7 @@ class AgendaItem < ActiveRecord::Base
 
   belongs_to :creator,
               class_name: "User"
+              
+  belongs_to :meeting
+
 end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -1,5 +1,6 @@
 class Meeting < ActiveRecord::Base
 
+  has_many :agenda_items
   has_many :meeting_permissions
   has_many :users, through: :meeting_permissions
   belongs_to :chair, 


### PR DESCRIPTION
An essential association that I did not make during database set up. Initially I thought this would be taken care of through the user-meeting_permission-creator associations...

- Meeting has_many agenda_items
- AgendaItem belongs_to meeting