### PR TITLE
Remove deployment db settings from development

### DIFF
--- a/config/database.rb
+++ b/config/database.rb
@@ -4,7 +4,6 @@ configure :development do
 end
 
 configure :development, :test do
-  set :database, ENV['DATABASE_URL']
 end
 
 configure :production do


### PR DESCRIPTION
**To address #87:**
- took out ENV['DATABASE_URL'] from configure method (seems to have slipped in during our merge to master before deployment...this should only appear there for when we are in deployment)